### PR TITLE
Feature: Add From<OriginalStruct> trait impl for derived struct

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -475,6 +475,7 @@ mod tests {
     duplicate_arg_panics_test!(attrs, "attrs already defined");
     duplicate_arg_panics_test!(field_doc, "field_doc already defined");
     duplicate_arg_panics_test!(field_attrs, "field_attrs already defined");
+    duplicate_arg_panics_test!(from, "from already defined");
 
     macro_rules! struct_name_not_first_panics {
         ($attr:meta) => {
@@ -497,6 +498,7 @@ mod tests {
     struct_name_not_first_panics!(attrs);
     struct_name_not_first_panics!(field_doc);
     struct_name_not_first_panics!(field_attrs);
+    struct_name_not_first_panics!(from);
 
     #[test]
     #[should_panic(expected = "expected opt struct name")]
@@ -542,6 +544,7 @@ mod tests {
         assert_eq!(args.attrs, None);
         assert_eq!(args.field_doc, false);
         assert_eq!(args.field_attrs, None);
+        assert_eq!(args.from, false);
     }
 
     #[test]
@@ -721,5 +724,15 @@ mod tests {
 
             assert_eq!(args.field_attrs, Some(attrs));
         }
+    }
+
+    #[test]
+    fn parse_from() {
+        let args = parse_args(quote! {
+            Opt,
+            from
+        });
+
+        assert!(args.from);
     }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -86,8 +86,8 @@ struct ArgList {
     attrs: Option<Span>,
     field_doc: Option<Span>,
     field_attrs: Option<Span>,
-    list: Vec<Arg>,
     from: Option<Span>,
+    list: Vec<Arg>,
 }
 
 impl Parse for Args {
@@ -169,8 +169,8 @@ impl ArgList {
             attrs: None,
             field_doc: None,
             field_attrs: None,
-            list: Vec::with_capacity(5),
             from: None,
+            list: Vec::with_capacity(6),
         }
     }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -11,6 +11,7 @@ mod kw {
     syn::custom_keyword!(attrs);
     syn::custom_keyword!(field_doc);
     syn::custom_keyword!(field_attrs);
+    syn::custom_keyword!(from);
 
     pub mod attrs_sub {
         syn::custom_keyword!(add);
@@ -26,6 +27,7 @@ pub struct Args {
     pub attrs: Option<Attrs>,
     pub field_doc: bool,
     pub field_attrs: Option<Attrs>,
+    pub from: bool,
 }
 
 enum Arg {
@@ -35,6 +37,7 @@ enum Arg {
     Attrs(Attrs),
     FieldDocs(bool),
     FieldAttrs(Attrs),
+    From(bool),
 }
 
 #[cfg_attr(test, derive(PartialEq))]
@@ -84,6 +87,7 @@ struct ArgList {
     field_doc: Option<Span>,
     field_attrs: Option<Span>,
     list: Vec<Arg>,
+    from: Option<Span>,
 }
 
 impl Parse for Args {
@@ -129,6 +133,8 @@ impl Parse for ArgList {
                 arg_list.parse_field_doc(&input)?;
             } else if lookahead.peek(kw::field_attrs) {
                 arg_list.parse_field_attrs(&input)?;
+            } else if lookahead.peek(kw::from) {
+                arg_list.parse_from(&input)?;
             } else {
                 return Err(lookahead.error());
             }
@@ -148,6 +154,7 @@ impl Args {
             attrs: None,
             field_doc: false,
             field_attrs: None,
+            from: false,
         }
     }
 }
@@ -163,6 +170,7 @@ impl ArgList {
             field_doc: None,
             field_attrs: None,
             list: Vec::with_capacity(5),
+            from: None,
         }
     }
 
@@ -173,6 +181,7 @@ impl ArgList {
             || input.peek(kw::field_doc)
             || input.peek(kw::field_attrs)
             || input.peek(kw::attrs)
+            || input.peek(kw::from)
     }
 
     fn parse_doc(&mut self, input: ParseStream) -> Result<()> {
@@ -259,6 +268,20 @@ impl ArgList {
 
         self.field_attrs = Some(span);
         self.list.push(Arg::FieldAttrs(field_attrs));
+
+        Ok(())
+    }
+
+    fn parse_from(&mut self, input: ParseStream) -> Result<()> {
+        if let Some(from_span) = self.from {
+            return ArgList::already_defined_error(input, "from", from_span);
+        }
+
+        let span = input.span();
+        input.parse::<kw::from>()?;
+
+        self.from = Some(span);
+        self.list.push(Arg::From(true));
 
         Ok(())
     }
@@ -408,6 +431,7 @@ impl From<ArgList> for Args {
                 Attrs(attrs) => args.attrs = Some(attrs),
                 FieldDocs(field_doc) => args.field_doc = field_doc,
                 FieldAttrs(field_attrs) => args.field_attrs = Some(field_attrs),
+                From(from) => args.from = from,
             }
         }
 

--- a/src/from.rs
+++ b/src/from.rs
@@ -1,0 +1,59 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Fields, Index, ItemStruct};
+
+use crate::args::Args;
+use crate::fields;
+
+pub fn generate(item: &ItemStruct, opt_item: &ItemStruct, args: &Args) -> TokenStream {
+    if args.from {
+        let item_name = &item.ident;
+
+        let opt_name = &opt_item.ident;
+        let opt_generics = &opt_item.generics;
+
+        let fields = field_bindings(&item.fields, args);
+
+        quote! {
+            impl#opt_generics From<#item_name#opt_generics> for #opt_name#opt_generics {
+                fn from(item: #item_name#opt_generics) -> #opt_name#opt_generics {
+                    #opt_name {
+                        #fields
+                    }
+                }
+            }
+        }
+    } else {
+        TokenStream::new()
+    }
+}
+
+fn field_bindings(fields: &Fields, args: &Args) -> TokenStream {
+    let mut tokens = TokenStream::new();
+
+    for (i, field) in fields.iter().enumerate() {
+        let field_name = match &field.ident {
+            // means that original item is a tuple struct
+            None => {
+                let index = Index::from(i);
+
+                quote!(#index)
+            }
+            Some(ident) => quote!(#ident),
+        };
+
+        let field_tokens = if fields::is_option(field) && !args.rewrap {
+            quote! {
+                #field_name: item.#field_name,
+            }
+        } else {
+            quote! {
+                #field_name: Some(item.#field_name),
+            }
+        };
+
+        tokens.extend(field_tokens);
+    }
+
+    tokens
+}

--- a/src/from.rs
+++ b/src/from.rs
@@ -8,6 +8,7 @@ use crate::fields;
 pub fn generate(item: &ItemStruct, opt_item: &ItemStruct, args: &Args) -> TokenStream {
     if args.from {
         let item_name = &item.ident;
+        let item_generics = &item.generics;
 
         let opt_name = &opt_item.ident;
         let opt_generics = &opt_item.generics;
@@ -15,8 +16,8 @@ pub fn generate(item: &ItemStruct, opt_item: &ItemStruct, args: &Args) -> TokenS
         let fields = field_bindings(&item.fields, args);
 
         quote! {
-            impl#opt_generics From<#item_name#opt_generics> for #opt_name#opt_generics {
-                fn from(item: #item_name#opt_generics) -> #opt_name#opt_generics {
+            impl#opt_generics From<#item_name#item_generics> for #opt_name#opt_generics {
+                fn from(item: #item_name#item_generics) -> #opt_name#opt_generics {
                     #opt_name {
                         #fields
                     }

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -3,7 +3,7 @@ use quote::quote;
 use syn::ItemStruct;
 
 use crate::args::Args;
-use crate::{attrs, fields, merge};
+use crate::{attrs, fields, from, merge};
 
 pub fn generate(original: &ItemStruct, args: Args) -> TokenStream {
     let mut opt_struct = original.clone();
@@ -16,10 +16,14 @@ pub fn generate(original: &ItemStruct, args: Args) -> TokenStream {
 
     let merge_impl = merge::generate(original, &opt_struct, &args);
 
+    let from_impl = from::generate(original, &opt_struct, &args);
+
     quote! {
         #opt_struct
 
         #merge_impl
+
+        #from_impl
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,6 +401,27 @@
 //! * custom name: `merge_fn = my_merge_fn`
 //! * custom visibility (default is private): `merge_fn = pub(crate)`
 //! * both: `merge_fn = pub my_merge_fn`
+//!
+//! # From
+//! When the `from` argument is used, `From<OriginalStruct>` is implemented for the OptStruct.
+//!
+//! ```
+//! # use optfield::*;
+//! #[optfield(Opt, from)]
+//! struct MyStruct {
+//!     text: String,
+//!     number: i32,
+//! }
+//!
+//! let original = MyStruct {
+//!     text: "super".to_string(),
+//!     number: 2,
+//! };
+//!
+//! let from = Opt::from(original);
+//! assert_eq!(from.text.unwrap(), "super");
+//! assert_eq!(from.number.unwrap(), 2);
+//! ```
 extern crate proc_macro;
 
 use crate::proc_macro::TokenStream;
@@ -411,6 +432,7 @@ mod args;
 mod attrs;
 mod error;
 mod fields;
+mod from;
 mod generate;
 mod merge;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,8 +403,7 @@
 //! * both: `merge_fn = pub my_merge_fn`
 //!
 //! # From
-//! When the `from` argument is used, `From<OriginalStruct>` is implemented for the OptStruct.
-//!
+//! When the `from` argument is used, `From<MyStruct>` is implemented for `Opt`.
 //! ```
 //! # use optfield::*;
 //! #[optfield(Opt, from)]

--- a/tests/from.rs
+++ b/tests/from.rs
@@ -33,13 +33,20 @@ fn from_struct() {
 }
 
 #[test]
-fn from_tup() {
+fn from_tuple_struct() {
     #[optfield(Opt, attrs, from)]
+    #[optfield(OptRewrap, attrs, rewrap, from)]
     #[derive(Clone, Debug, PartialEq)]
-    struct Original(i32, String);
+    struct Original<T>(i32, String, Option<T>);
 
-    let original = Original(21, "test".to_string());
+    let original = Original(21, "test".to_string(), Some(1));
     let opt = Opt::from(original.clone());
     assert_eq!(original.0, opt.0.unwrap());
     assert_eq!(original.1, opt.1.unwrap());
+    assert_eq!(original.2, opt.2);
+
+    let opt_rewrap = OptRewrap::from(original.clone());
+    assert_eq!(original.0, opt_rewrap.0.unwrap());
+    assert_eq!(original.1, opt_rewrap.1.unwrap());
+    assert_eq!(original.2, opt_rewrap.2.unwrap());
 }

--- a/tests/from.rs
+++ b/tests/from.rs
@@ -1,0 +1,45 @@
+use optfield::optfield;
+
+#[test]
+fn from_struct() {
+    #[optfield(Opt, attrs, from)]
+    #[optfield(OptRewrap, attrs, rewrap, from)]
+    #[derive(Clone, Debug, PartialEq)]
+    struct Original<'a, T> {
+        number: u32,
+        text: &'a str,
+        generic: T,
+        optional: Option<&'a [u8]>,
+    }
+
+    let original = Original {
+        number: 12,
+        text: "test",
+        generic: "testing".to_string(),
+        optional: Some(&[1, 2, 3, 4, 5]),
+    };
+
+    let opt = Opt::from(original.clone());
+    assert_eq!(original.number, opt.number.unwrap());
+    assert_eq!(original.text, opt.text.unwrap());
+    assert_eq!(original.generic, opt.generic.unwrap());
+    assert_eq!(original.optional, opt.optional);
+
+    let opt_rewrap = OptRewrap::from(original.clone());
+    assert_eq!(original.number, opt_rewrap.number.unwrap());
+    assert_eq!(original.text, opt_rewrap.text.unwrap());
+    assert_eq!(original.generic, opt_rewrap.generic.unwrap());
+    assert_eq!(original.optional, opt_rewrap.optional.unwrap());
+}
+
+#[test]
+fn from_tup() {
+    #[optfield(Opt, attrs, from)]
+    #[derive(Clone, Debug, PartialEq)]
+    struct Original(i32, String);
+
+    let original = Original(21, "test".to_string());
+    let opt = Opt::from(original.clone());
+    assert_eq!(original.0, opt.0.unwrap());
+    assert_eq!(original.1, opt.1.unwrap());
+}


### PR DESCRIPTION
where each field of the derived struct is `Some(original_struct.field)` or the field itself if field is option and rewrap is not specified. Turn on/off with the new `from` keyword