### PR TITLE
Add support for renaming types when generating optionals struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ struct Opt<T> {
 }
 ```
 
-`optfield` supports defining visibility, documentation, attributes and merge
-methods. For more details and examples check its [documentation].
+`optfield` supports defining visibility, documentation, attributes, renaming
+types and merge methods. For more details and examples check its
+[documentation].
 
 ### License
 Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,6 +354,43 @@
 //! }
 //! ```
 //!
+//! # Field Type Renaming
+//! You can change which types will be used in the output in order to support
+//! embedded structures which also go through `optfield`.
+//!
+//! ```
+//! # use optfield::*;
+//!
+//! #[optfield(OptAnotherStruct)]
+//! struct AnotherStruct(String);
+//! #[optfield(OptYetAnotherStruct)]
+//! struct YetAnotherStruct(u32);
+//!
+//! #[optfield(
+//!     Opt,
+//!     renames = (
+//!         AnotherStruct = OptAnotherStruct,
+//!         YetAnotherStruct = OptYetAnotherStruct
+//!     )
+//! )]
+//! struct MyStruct {
+//!     other_struct: AnotherStruct,
+//!     yet_another_struct: YetAnotherStruct,
+//!     my_number: i32
+//! }
+//! ```
+//! Will generate:
+//! ```
+//! struct OptAnotherStruct(String);
+//! struct OptYetAnotherStruct(u32);
+//!
+//! struct Opt {
+//!     other_struct: OptAnotherStruct,
+//!     yet_another_struct: OptYetAnotherStruct,
+//!     my_number: Option<i32>
+//! }
+//! ```
+//!
 //! # Merging
 //! When the  `merge_fn` argument is used `optfield` will add a method to the
 //! original struct that merges an opt struct back into the original.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,6 +439,9 @@
 //! * custom visibility (default is private): `merge_fn = pub(crate)`
 //! * both: `merge_fn = pub my_merge_fn`
 //!
+//! Note that if you use `merge_fn` in combination with `renames`, all the merge
+//! functions for those types must have the same name.
+//!
 //! # From
 //! When the `from` argument is used, `From<MyStruct>` is implemented for `Opt`.
 //! ```

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -22,7 +22,7 @@ pub fn generate(item: &ItemStruct, opt_item: &ItemStruct, args: &Args) -> TokenS
         let opt_name = &opt_item.ident;
         let opt_generics = &opt_item.generics;
 
-        let fields = field_bindings(&item.fields, args);
+        let fields = field_bindings(&item.fields, args, &fn_name);
 
         quote! {
             impl#item_generics #item_name#item_generics {
@@ -36,7 +36,7 @@ pub fn generate(item: &ItemStruct, opt_item: &ItemStruct, args: &Args) -> TokenS
     }
 }
 
-fn field_bindings(fields: &Fields, args: &Args) -> TokenStream {
+fn field_bindings(fields: &Fields, args: &Args, fn_name: &Ident) -> TokenStream {
     let mut tokens = TokenStream::new();
 
     for (i, field) in fields.iter().enumerate() {
@@ -55,6 +55,10 @@ fn field_bindings(fields: &Fields, args: &Args) -> TokenStream {
                 if opt.#field_name.is_some() {
                     self.#field_name = opt.#field_name;
                 }
+            }
+        } else if fields::find_rename(field, args).is_some() {
+            quote! {
+                self.#field_name.#fn_name(opt.#field_name);
             }
         } else {
             quote! {

--- a/tests/merge.rs
+++ b/tests/merge.rs
@@ -152,3 +152,50 @@ fn merge_tuple_struct() {
     assert_eq!(original_clone.0, opt4.0.unwrap());
     assert_eq!(original_clone.1, opt4.1.unwrap());
 }
+
+#[test]
+fn merge_structs_with_rename() {
+    #[optfield(OptAnotherStruct, merge_fn)]
+    #[derive(Clone, Debug, PartialEq)]
+    struct AnotherStruct(String);
+
+    #[optfield(OptYetAnotherStruct, merge_fn)]
+    #[derive(Clone, Debug, PartialEq)]
+    struct YetAnotherStruct(u32);
+
+    #[optfield(
+        Opt, merge_fn,
+        renames = (
+            AnotherStruct = OptAnotherStruct,
+            YetAnotherStruct = OptYetAnotherStruct,
+        )
+    )]
+    #[derive(Clone, Debug, PartialEq)]
+    struct Original {
+        my_integer: i32,
+        another_struct: AnotherStruct,
+        yet_another_struct: YetAnotherStruct,
+    }
+
+    let original = Original {
+        my_integer: 3,
+        another_struct: AnotherStruct("original".to_string()),
+        yet_another_struct: YetAnotherStruct(5),
+    };
+    let mut original_clone = original.clone();
+
+    let opt = Opt {
+        my_integer: Some(42),
+        another_struct: OptAnotherStruct(Some("foo".to_string())),
+        yet_another_struct: OptYetAnotherStruct(None),
+    };
+
+    original_clone.merge_opt(opt);
+
+    assert_eq!(original_clone.my_integer, 42);
+    assert_eq!(
+        original_clone.another_struct,
+        AnotherStruct("foo".to_string())
+    );
+    assert_eq!(original_clone.yet_another_struct, YetAnotherStruct(5));
+}


### PR DESCRIPTION
The goal here is to better support situations where you have something like

```rust
#[optfield(OptPorts)]
struct Ports {
    database: u16,
    auth: u16,
}

#[optfield(OptStats)]
struct Stats {
    port: u16,
    endpoint: Option<String>,
}

#[optfield(Opt)]
struct Options {
    ports: Ports,
    stats: Stats,
    daemonize: bool,
}
```

and don't want `Option<Ports>` but rather `OptPorts` in `Opt`.

This allows for e.g. a configuration file on disk to have the same structure and for everything to be optional recursively, instead of having to have these other structs be all-or-nothing and falling back to the defaults when we deserialise.

With these changes, you can specify

```rust
#[optfield(
    Opt,
    renames = (
        Ports = OptPorts,
        Stats = OptStats,
    )
)]
struct Options {
    ports: Ports,
    stats: Stats,
    daemonize: bool,
}
```

and the resulting `struct` can be merged from what we're able to read from disk without touching any of the fields that weren't specified in there.

I followed roughly the pattern that exists here with `attrs`  where we specify everything at the head of the struct instead of e.g. specifying the attribute per field. But let me know if you think there's a better name or pattern.

One unfortunate restriction here is that if we use `renames` and `merge_fn`, all the functions have to be called the same as (IIUC) we don't (can't?) store what merge function name was used for the other `struct`s. We could have the user specify them as part of the renames, but I figure that it's most likely that, if overriding at all, there would be a standard name used in a project so I wouldn't expect this to be an issue in practice.