### PR TITLE
Fix clippy warning about needless borrow

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -104,7 +104,7 @@ impl Parse for ArgList {
             return Err(input.error("expected opt struct name"));
         }
 
-        if ArgList::next_is_kw(&input) {
+        if ArgList::next_is_kw(input) {
             return Err(input.error("first argument must be opt struct name"));
         }
 
@@ -122,19 +122,19 @@ impl Parse for ArgList {
             let lookahead = input.lookahead1();
 
             if lookahead.peek(kw::doc) {
-                arg_list.parse_doc(&input)?;
+                arg_list.parse_doc(input)?;
             } else if lookahead.peek(kw::merge_fn) {
-                arg_list.parse_merge(&input)?;
+                arg_list.parse_merge(input)?;
             } else if lookahead.peek(kw::rewrap) {
-                arg_list.parse_rewrap(&input)?;
+                arg_list.parse_rewrap(input)?;
             } else if lookahead.peek(kw::attrs) {
-                arg_list.parse_attrs(&input)?;
+                arg_list.parse_attrs(input)?;
             } else if lookahead.peek(kw::field_doc) {
-                arg_list.parse_field_doc(&input)?;
+                arg_list.parse_field_doc(input)?;
             } else if lookahead.peek(kw::field_attrs) {
-                arg_list.parse_field_attrs(&input)?;
+                arg_list.parse_field_attrs(input)?;
             } else if lookahead.peek(kw::from) {
-                arg_list.parse_from(&input)?;
+                arg_list.parse_from(input)?;
             } else {
                 return Err(lookahead.error());
             }

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -18,7 +18,7 @@ pub fn generate(item: &ItemStruct, args: &Args) -> Fields {
         field.attrs = attrs::generate(field, args);
         attrs::generate(field, args);
 
-        if is_option(&field) && !args.rewrap {
+        if is_option(field) && !args.rewrap {
             continue;
         }
 


### PR DESCRIPTION
Clippy has started complaining about this so let's make mainline pass the linter
test.

#2 is failing the linter test but it's following the pattern laid out in mainline, so we probably shouldn't fix that there. So here's a different PR to make `master` pass so that and any other PRs just have to their own issues to deal with.