### PR TITLE
Add empty rustfmt.toml to enforce default formatter settings

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-# Enforce default formatter settings.
+# Use default formatter settings.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+# Enforce default formatter settings.


### PR DESCRIPTION
See https://github.com/sharkdp/bat/pull/2068