### PR TITLE
Support setting doc & attribute for each field separately

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+# Enforce default formatter settings.

--- a/src/attrs/generator.rs
+++ b/src/attrs/generator.rs
@@ -1,86 +1,37 @@
 use quote::quote;
 use syn::{parse::Parser, Attribute, Meta};
 
-use crate::args::Attrs;
 use crate::error;
 
 const DOC: &str = "doc";
-const OPT_ATTR: &str = "optfield";
+const OPTFIELD_ATTR_NAME: &str = "optfield";
 
 pub trait AttrGenerator {
-    fn no_docs(&self) -> bool;
-
     fn error_action_text(&self) -> String;
 
-    fn original_attrs(&self) -> &[Attribute];
+    fn new_attrs_except_docs(&self) -> Vec<Meta>;
 
-    fn attrs_arg(&self) -> &Option<Attrs>;
-
-    fn custom_docs(&self) -> Option<Meta> {
-        None
-    }
-
-    fn keep_original_docs(&self) -> bool {
-        !self.no_docs()
-    }
-
-    fn compute_capacity(&self) -> usize {
-        use Attrs::*;
-
-        let orig_len = self.original_attrs().len();
-
-        match self.attrs_arg() {
-            Some(Replace(v)) | Some(Add(v)) => orig_len + v.len(),
-            _ => orig_len,
-        }
-    }
+    fn new_docs(&self) -> Vec<Meta>;
 
     fn generate(&self) -> Vec<Attribute> {
-        use Attrs::*;
-
-        let attrs_arg = self.attrs_arg();
-
-        // if no attrs and no docs should be set, remove all attrs
-        if self.no_docs() && attrs_arg.is_none() {
-            return Vec::new();
-        }
-
-        let mut new_attrs = Vec::with_capacity(self.compute_capacity());
-
-        if let Some(d) = self.custom_docs() {
-            new_attrs.push(d);
-        }
-
-        for attr in self.original_attrs() {
-            let mut add_attr = self.keep_original_docs() && is_doc_attr(attr);
-
-            if let Some(Keep) | Some(Add(_)) = attrs_arg {
-                if !is_doc_attr(attr) {
-                    add_attr = true;
-                }
-            }
-
-            if attr.path().is_ident(OPT_ATTR) {
-                add_attr = false
-            }
-
-            if add_attr {
-                new_attrs.push(attr.meta.clone());
-            }
-        }
-
-        if let Some(Replace(v)) | Some(Add(v)) = attrs_arg {
-            new_attrs.extend(v.clone());
-        }
+        let attrs_except_docs = self.new_attrs_except_docs();
+        let docs = self.new_docs();
 
         let attrs_tokens = quote! {
-            #(#[#new_attrs])*
+            #(#[#attrs_except_docs])*
+            #(#[#docs])*
         };
 
         Attribute::parse_outer
             .parse2(attrs_tokens)
             .unwrap_or_else(|e| panic!("{}", error::unexpected(self.error_action_text(), e)))
     }
+}
+
+/// Useful during attribute generation: it can prevent some unwanted recursive
+/// behaviour.
+pub fn is_optfield_attr(attr: &Attribute) -> bool {
+    attr.path().is_ident(OPTFIELD_ATTR_NAME)
 }
 
 pub fn is_doc_attr(attr: &Attribute) -> bool {

--- a/src/fields/args.rs
+++ b/src/fields/args.rs
@@ -1,0 +1,132 @@
+use proc_macro2::Span;
+use syn::{
+    parse::{Parse, ParseStream, Result},
+    token::Comma,
+    Error,
+};
+
+use crate::args::{kw, Attrs, Doc};
+
+/// Args declared on a field.
+pub struct FieldArgs {
+    pub doc: Option<Doc>,
+    pub attrs: Option<Attrs>,
+}
+impl Parse for FieldArgs {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let arg_list: FieldArgList = input.parse()?;
+
+        Ok(arg_list.into())
+    }
+}
+impl FieldArgs {
+    fn new() -> Self {
+        Self {
+            doc: None,
+            attrs: None,
+        }
+    }
+}
+
+enum FieldArg {
+    Doc(Doc),
+    Attrs(Attrs),
+}
+
+/// Parser for unordered args on a field.
+struct FieldArgList {
+    doc: Option<Span>,
+    attrs: Option<Span>,
+    list: Vec<FieldArg>,
+}
+impl Parse for FieldArgList {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut arg_list = FieldArgList::new();
+
+        while !input.is_empty() {
+            input.parse::<Comma>()?;
+
+            // allow trailing commas
+            if input.is_empty() {
+                break;
+            }
+
+            let lookahead = input.lookahead1();
+
+            if lookahead.peek(kw::doc) {
+                arg_list.parse_doc(input)?;
+            } else if lookahead.peek(kw::attrs) {
+                arg_list.parse_attrs(input)?;
+            } else {
+                return Err(lookahead.error());
+            }
+        }
+
+        Ok(arg_list)
+    }
+}
+impl From<FieldArgList> for FieldArgs {
+    fn from(arg_list: FieldArgList) -> Self {
+        use FieldArg::*;
+
+        let mut args = FieldArgs::new();
+
+        for arg in arg_list.list {
+            match arg {
+                Doc(doc) => args.doc = Some(doc),
+                Attrs(attrs) => args.attrs = Some(attrs),
+            }
+        }
+
+        args
+    }
+}
+impl FieldArgList {
+    fn new() -> Self {
+        Self {
+            doc: None,
+            attrs: None,
+            list: Vec::with_capacity(2),
+        }
+    }
+
+    fn parse_doc(&mut self, input: ParseStream) -> Result<()> {
+        if let Some(doc_span) = self.doc {
+            return FieldArgList::already_defined_error(input, "doc", doc_span);
+        }
+
+        let span = input.span();
+        let doc: Doc = input.parse()?;
+
+        self.doc = Some(span);
+        self.list.push(FieldArg::Doc(doc));
+
+        Ok(())
+    }
+
+    fn parse_attrs(&mut self, input: ParseStream) -> Result<()> {
+        if let Some(attrs_span) = self.attrs {
+            return FieldArgList::already_defined_error(input, "attrs", attrs_span);
+        }
+
+        let span = input.span();
+
+        input.parse::<kw::attrs>()?;
+        let attrs: Attrs = input.parse()?;
+
+        self.attrs = Some(span);
+        self.list.push(FieldArg::Attrs(attrs));
+
+        Ok(())
+    }
+
+    fn already_defined_error(
+        input: ParseStream,
+        arg_name: &'static str,
+        prev_span: Span,
+    ) -> Result<()> {
+        let mut e = input.error(format!("{} already defined", arg_name));
+        e.combine(Error::new(prev_span, format!("{} defined here", arg_name)));
+        Err(e)
+    }
+}

--- a/src/fields/attrs.rs
+++ b/src/fields/attrs.rs
@@ -1,7 +1,12 @@
-use syn::{Attribute, Field};
+use quote::quote;
+use syn::{parse2, Attribute, Field, Meta};
 
-use crate::args::{Args, Attrs};
-use crate::attrs::generator::AttrGenerator;
+use crate::args::{Args, Attrs, Doc};
+use crate::attrs::generator::{is_doc_attr, AttrGenerator};
+use crate::error::unexpected;
+use crate::fields::args::FieldArgs;
+
+const OPTFIELD_FIELD_ATTR_NAME: &str = "optfield";
 
 struct FieldAttrGen<'a> {
     field: &'a Field,
@@ -12,13 +17,34 @@ impl<'a> FieldAttrGen<'a> {
     fn new(field: &'a Field, args: &'a Args) -> Self {
         Self { field, args }
     }
+
+    /// Get the #[optfield(...)] args on this field, if the attribute exists.
+    fn optfield_args(&self) -> Option<FieldArgs> {
+        let mut optfield_field_attrs_it = self
+            .field
+            .attrs
+            .iter()
+            .filter_map(|attr| is_optfield_field_attr(attr).then(|| &attr.meta));
+
+        let attr = match optfield_field_attrs_it.next() {
+            Some(attr) => attr,
+            None => return None,
+        };
+
+        if optfield_field_attrs_it.next().is_some() {
+            panic!("There can be at most 1 optfield attribute on each field.");
+        }
+
+        let args: FieldArgs = match attr {
+            Meta::Path(_) | Meta::NameValue(_) => panic!("Expected parentheses."),
+            Meta::List(list) => list.parse_args().unwrap_or_else(|e| panic!("{}", e)),
+        };
+
+        Some(args)
+    }
 }
 
 impl<'a> AttrGenerator for FieldAttrGen<'a> {
-    fn no_docs(&self) -> bool {
-        !self.args.field_doc
-    }
-
     fn error_action_text(&self) -> String {
         let field_name = match &self.field.ident {
             None => "".to_string(),
@@ -28,17 +54,85 @@ impl<'a> AttrGenerator for FieldAttrGen<'a> {
         format!("generating {}field attrs", field_name)
     }
 
-    fn original_attrs(&self) -> &[Attribute] {
-        &self.field.attrs
+    fn new_attrs_except_docs(&self) -> Vec<Meta> {
+        use Attrs::*;
+
+        let struct_attrs_arg = &self.args.field_attrs;
+
+        let original_attrs_it = self
+            .field
+            .attrs
+            .iter()
+            .filter_map(|attr| (!is_doc_attr(attr)).then(|| attr.meta.clone()));
+
+        let attr_attrs_arg = self.optfield_args().and_then(|args| args.attrs);
+
+        // field arg overrides struct arg
+        match (struct_attrs_arg, attr_attrs_arg) {
+            // no attributes
+            (None, None) => vec![],
+            // keep original
+            (Some(Keep), None) => original_attrs_it.collect(),
+            // replace with attributes defined on struct
+            (Some(Replace(attrs)), None) => attrs.clone(),
+            // add attributes defined on struct
+            (Some(Add(attrs)), None) => original_attrs_it.chain(attrs.iter().cloned()).collect(),
+            // keep original (field arg override)
+            (_, Some(Keep)) => original_attrs_it.collect(),
+            // replace with attributes defined on field (field arg override)
+            (_, Some(Replace(attrs))) => attrs,
+            // add attributes defined on field (field arg override)
+            (_, Some(Add(attrs))) => original_attrs_it.chain(attrs).collect(),
+        }
     }
 
-    fn attrs_arg(&self) -> &Option<Attrs> {
-        &self.args.field_attrs
+    fn new_docs(&self) -> Vec<Meta> {
+        use Doc::*;
+
+        let struct_doc_arg = self.args.field_doc;
+
+        let original_doc_it = self
+            .field
+            .attrs
+            .iter()
+            .filter_map(|attr| is_doc_attr(attr).then(|| attr.meta.clone()));
+
+        let attr_doc_arg = self.optfield_args().and_then(|args| args.doc);
+
+        // field arg overrides struct arg
+        match (struct_doc_arg, attr_doc_arg) {
+            // no docs
+            (false, None) => vec![],
+            // keep original
+            (true, None) => original_doc_it.collect(),
+            // keep original (field arg override)
+            (_, Some(Keep)) => original_doc_it.collect(),
+            // replace with doc on field
+            (_, Some(Replace(doc_text))) => {
+                let tokens = quote! { doc = #doc_text };
+                let doc_attr = parse2(tokens)
+                    .unwrap_or_else(|e| panic!("{}", unexpected(self.error_action_text(), e)));
+                vec![doc_attr]
+            }
+            // append to original with doc on field
+            (_, Some(Append(doc_text))) => {
+                let tokens = quote! { doc = #doc_text };
+                let doc_attr = parse2(tokens)
+                    .unwrap_or_else(|e| panic!("{}", unexpected(self.error_action_text(), e)));
+                original_doc_it.chain(std::iter::once(doc_attr)).collect()
+            }
+        }
     }
 }
 
 pub fn generate(field: &Field, args: &Args) -> Vec<Attribute> {
     FieldAttrGen::new(field, args).generate()
+}
+
+/// This currently has the same implementation as `is_optfield_attr`, but they
+/// are semantically distinct, and therefore have separate functions.
+pub fn is_optfield_field_attr(attr: &Attribute) -> bool {
+    attr.path().is_ident(OPTFIELD_FIELD_ATTR_NAME)
 }
 
 #[cfg(test)]

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -4,6 +4,7 @@ use syn::{parse2, Field, Fields, ItemStruct, Path, Type, TypePath};
 use crate::args::Args;
 use crate::error::unexpected;
 
+mod args;
 mod attrs;
 
 const OPTION: &str = "Option";
@@ -16,7 +17,6 @@ pub fn generate(item: &ItemStruct, args: &Args) -> Fields {
 
     for field in fields.iter_mut() {
         field.attrs = attrs::generate(field, args);
-        attrs::generate(field, args);
 
         if is_option(field) && !args.rewrap {
             continue;


### PR DESCRIPTION
## Summary
Basically, this PR would allow you to do this:
```rust
#[optfield(Opt)]
struct Foo {
    #[optfield(attrs = (bar), doc = "69420")]
    foo: String,
}
```
... which generates
```rust
struct Opt {
    #[bar]
    #[doc = "69420"]
    foo: Option<String>,
}
```

## Checklist
- [x] implementation
- [ ] relevant tests
